### PR TITLE
Fix a linker error in ninja_test_hypre_parasails

### DIFF
--- a/test/ninja_test_hypre_parasails.c
+++ b/test/ninja_test_hypre_parasails.c
@@ -306,7 +306,7 @@ int comm_size;
 
 #define LEN (64)
 float calibration = 1;
-int a[LEN];
+static int a[LEN];
 static void do_noise_work(float msec, int bool)
 {
 #ifdef ENABLE_NOISE

--- a/test/ninja_test_util.c
+++ b/test/ninja_test_util.c
@@ -31,7 +31,7 @@
 
 #define LEN (2)
 int lpusec;
-int a[LEN];
+static int a[LEN];
 static void do_noise_work(int loops)
 { 
   int i;


### PR DESCRIPTION
The symbol is defined as a global symbol in both object files. This error wasn't detect by gcc versions before 10.0.

@dongahn This was detected as part of my work on the ECP Software Development Tools SDK.